### PR TITLE
Only loads lf_icons if file exists

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -12,7 +12,9 @@ set fish_greeting
 
 starship init fish | source
 
-source $HOME/.dotfiles/fish/lf_icons.fish
+if test -f "$HOME/.dotfiles/fish/lf_icons.fish"
+  source $HOME/.dotfiles/fish/lf_icons.fish
+end
 
 export FZF_DEFAULT_COMMAND="fd -H"
 export BROWSER="/usr/bin/librewolf"


### PR DESCRIPTION
Only loads lf_icons file if the file exists, preventing errors when you load the config.fish and the file doesn't exist.