### PR TITLE
Changed neovim and Helix aliases to functions

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -6,8 +6,22 @@
 end
 
 alias l "eza -lag --sort=type"
-alias v "nvim (fzf)"
-alias h "hx (fzf)"
+
+function v
+    if test -n "$argv"
+        nvim $argv
+    else
+        nvim (fzf)
+    end
+end
+
+function h
+    if test -n "$argv"
+        hx $argv
+    else
+        hx (fzf)
+    end
+end
 
 fish_add_path $HOME/.cargo/bin/
 


### PR DESCRIPTION
With the functions instead of the aliases, you can use `v` or `h` with or without arguments.

If you use without arguments, it will run the program with `fzf`.

If you use with arguments, it will run the program normally.